### PR TITLE
Contribution from b9d2e3ad4eeba46b2d206d9e9d4ea80692c5caa7f50d04572874007c20b5ed78

### DIFF
--- a/attestations/0001_0xb9d2e3ad4eeba46b2d206d9e9d4ea80692c5caa7f50d04572874007c20b5ed78.txt
+++ b/attestations/0001_0xb9d2e3ad4eeba46b2d206d9e9d4ea80692c5caa7f50d04572874007c20b5ed78.txt
@@ -1,0 +1,10 @@
+Ceremony Contribution
+Participant: 0xb9d2e3ad4eeba46b2d206d9e9d4ea80692c5caa7f50d04572874007c20b5ed78
+Key: ceremony_0001.zkey
+Input Key: ceremony_0000.zkey
+Circuit: identity_with_merkle
+Attestation Hash: 4f1735330af4dcdf89ba3c7863e3e52cae31301be09558709749987d673ea5ad
+Timestamp: 2025-11-26T02:18:45.184Z
+
+IMPORTANT: Delete your local copy of this key after passing it to the next contributor!
+This is the "toxic waste" that must be destroyed for security.

--- a/ceremony_state.json
+++ b/ceremony_state.json
@@ -1,13 +1,19 @@
 {
   "initiator": "0x21a1d74bf75776432ffc94163ddb4bffe35b0b78e7ab8fcb7401ebac0ddb32d9",
-  "phase": "init",
-  "currentKey": 0,
+  "phase": "contributing",
+  "currentKey": 1,
   "contributors": [
     {
       "name": "0x21a1d74bf75776432ffc94163ddb4bffe35b0b78e7ab8fcb7401ebac0ddb32d9",
       "keyNumber": 0,
       "timestamp": 1764005779477,
       "attestationHash": "bca635d25291be4dfbc2b59bda96fc4e0516f0f387e0148fdde05005b4e2360f"
+    },
+    {
+      "name": "0xb9d2e3ad4eeba46b2d206d9e9d4ea80692c5caa7f50d04572874007c20b5ed78",
+      "keyNumber": 1,
+      "timestamp": 1764123525184,
+      "attestationHash": "4f1735330af4dcdf89ba3c7863e3e52cae31301be09558709749987d673ea5ad"
     }
   ],
   "circuitName": "identity_with_merkle",


### PR DESCRIPTION
### **User description**
Attestation Hash: 4f1735330af4dcdf89ba3c7863e3e52cae31301be09558709749987d673ea5ad


___

### **PR Type**
Other


___

### **Description**
- Adds attestation record for ceremony contributor 0xb9d2e3ad4eeba46b2d206d9e9d4ea80692c5caa7f50d04572874007c20b5ed78

- Updates ceremony state to reflect new contributor and phase progression

- Documents contribution details including key number, timestamp, and attestation hash

- Includes security reminder about deleting toxic waste after contribution


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Ceremony Init<br/>Phase: init<br/>CurrentKey: 0"] -->|"Contributor 0xb9d2e3ad<br/>Submits Contribution"| B["Ceremony Contributing<br/>Phase: contributing<br/>CurrentKey: 1"]
  B -->|"Attestation Record<br/>Created"| C["Attestation File<br/>0001_0xb9d2e3ad...txt"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>0001_0xb9d2e3ad4eeba46b2d206d9e9d4ea80692c5caa7f50d04572874007c20b5ed78.txt</strong><dd><code>New ceremony contribution attestation record</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

attestations/0001_0xb9d2e3ad4eeba46b2d206d9e9d4ea80692c5caa7f50d04572874007c20b5ed78.txt

<ul><li>Creates new attestation file documenting ceremony contribution<br> <li> Records participant identity, key references, and circuit information<br> <li> Includes attestation hash and timestamp for verification<br> <li> Adds security warning about deleting local key copy</ul>


</details>


  </td>
  <td><a href="https://github.com/kynesyslabs/zk_ceremony/pull/2/files#diff-77991f994868af08af5602606bbb886025c01f09e1c5284dbcd2c5685d4dc8ed">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ceremony_state.json</strong><dd><code>Update ceremony state with new contributor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ceremony_state.json

<ul><li>Updates phase from "init" to "contributing"<br> <li> Increments currentKey from 0 to 1<br> <li> Adds new contributor entry with participant 0xb9d2e3ad<br> <li> Records contributor's key number, timestamp, and attestation hash</ul>


</details>


  </td>
  <td><a href="https://github.com/kynesyslabs/zk_ceremony/pull/2/files#diff-d8d8a9fb0fcd5cdefc22048b9a4eb43326eb68994e1d1adcf3041c857ab65387">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added attestation record documenting ceremony participation with contributor details and security guidelines.

* **Chores**
  * Updated ceremony state to reflect progression to active contribution phase and recorded new participant information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->