### PR TITLE
Add ZK ceremony contribution 0002 for 0x05c9306...

### DIFF
--- a/attestations/0002_0x05c9306144e9c508f53053eea02f5199e7c7890df37359ce2b93b97c5b53dde2.txt
+++ b/attestations/0002_0x05c9306144e9c508f53053eea02f5199e7c7890df37359ce2b93b97c5b53dde2.txt
@@ -1,0 +1,10 @@
+Ceremony Contribution
+Participant: 0x05c9306144e9c508f53053eea02f5199e7c7890df37359ce2b93b97c5b53dde2
+Key: ceremony_0002.zkey
+Input Key: ceremony_0001.zkey
+Circuit: identity_with_merkle
+Attestation Hash: 87f767c260ceba37ef76f72bcf07a098fe0f0669ea9c5ae7f196e6baf8a0ac8f
+Timestamp: 2025-12-01T15:12:12.974Z
+
+IMPORTANT: Delete your local copy of this key after passing it to the next contributor!
+This is the "toxic waste" that must be destroyed for security.

--- a/ceremony_state.json
+++ b/ceremony_state.json
@@ -1,7 +1,7 @@
 {
   "initiator": "0x21a1d74bf75776432ffc94163ddb4bffe35b0b78e7ab8fcb7401ebac0ddb32d9",
   "phase": "contributing",
-  "currentKey": 1,
+  "currentKey": 2,
   "contributors": [
     {
       "name": "0x21a1d74bf75776432ffc94163ddb4bffe35b0b78e7ab8fcb7401ebac0ddb32d9",
@@ -14,6 +14,12 @@
       "keyNumber": 1,
       "timestamp": 1764123525184,
       "attestationHash": "4f1735330af4dcdf89ba3c7863e3e52cae31301be09558709749987d673ea5ad"
+    },
+    {
+      "name": "0x05c9306144e9c508f53053eea02f5199e7c7890df37359ce2b93b97c5b53dde2",
+      "keyNumber": 2,
+      "timestamp": 1764601932975,
+      "attestationHash": "87f767c260ceba37ef76f72bcf07a098fe0f0669ea9c5ae7f196e6baf8a0ac8f"
     }
   ],
   "circuitName": "identity_with_merkle",


### PR DESCRIPTION
### **PR Type**
Other


___

### **Description**
- Add ZK ceremony contribution attestation for participant 0x05c9306...

- Update ceremony state to reflect new contributor and increment key number

- Document contribution details including key hash and timestamp


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Ceremony State"] -->|"Increment currentKey"| B["currentKey: 2"]
  A -->|"Add new contributor"| C["Contributor 0x05c9306..."]
  D["Attestation File"] -->|"Record contribution"| C
  C -->|"Update state"| E["Updated ceremony_state.json"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>0002_0x05c9306144e9c508f53053eea02f5199e7c7890df37359ce2b93b97c5b53dde2.txt</strong><dd><code>Create ZK ceremony contribution attestation file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

attestations/0002_0x05c9306144e9c508f53053eea02f5199e7c7890df37359ce2b93b97c5b53dde2.txt

<ul><li>Create new attestation file for ceremony contribution 0002<br> <li> Record participant address, key identifiers, and circuit name<br> <li> Include attestation hash and timestamp for verification<br> <li> Add security warning about deleting local key copy</ul>


</details>


  </td>
  <td><a href="https://github.com/kynesyslabs/zk_ceremony/pull/5/files#diff-e47e62de9269ae8b3cdb442892dfd7c3ae34a95e7bbae1aaa3388af4a12bc611">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ceremony_state.json</strong><dd><code>Update ceremony state with new contributor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ceremony_state.json

<ul><li>Increment <code>currentKey</code> from 1 to 2 to reflect new contribution<br> <li> Add new contributor entry with participant address 0x05c9306...<br> <li> Record keyNumber 2, timestamp, and attestation hash for new <br>contributor<br> <li> Maintain ceremony phase and circuit name</ul>


</details>


  </td>
  <td><a href="https://github.com/kynesyslabs/zk_ceremony/pull/5/files#diff-d8d8a9fb0fcd5cdefc22048b9a4eb43326eb68994e1d1adcf3041c857ab65387">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ceremony state to reflect progression to the next phase.
  * Recorded new participant contribution and corresponding attestation entry in the ceremony records.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->