### PR TITLE
contrib: contribution from 0x6120898bd711d52a5f7fb8bbae2cef10b334d33e…

### DIFF
--- a/attestations/0004_0x6120898bd711d52a5f7fb88bae2cef10b334d33e8835e7a34f2cdeb7017e008c.txt
+++ b/attestations/0004_0x6120898bd711d52a5f7fb88bae2cef10b334d33e8835e7a34f2cdeb7017e008c.txt
@@ -1,0 +1,10 @@
+Ceremony Contribution
+Participant: 0x6120898bd711d52a5f7fb88bae2cef10b334d33e8835e7a34f2cdeb7017e008c
+Key: ceremony_0004.zkey
+Input Key: ceremony_0003.zkey
+Circuit: identity_with_merkle
+Attestation Hash: 1dc4268f5c4aae595bfbdc24ecd1e4f76c22d9267ecdff51b9573322c1c11948
+Timestamp: 2025-12-02T19:09:07.537Z
+
+IMPORTANT: Delete your local copy of this key after passing it to the next contributor!
+This is the "toxic waste" that must be destroyed for security.

--- a/ceremony_state.json
+++ b/ceremony_state.json
@@ -1,7 +1,7 @@
 {
   "initiator": "0x21a1d74bf75776432ffc94163ddb4bffe35b0b78e7ab8fcb7401ebac0ddb32d9",
   "phase": "contributing",
-  "currentKey": 3,
+  "currentKey": 4,
   "contributors": [
     {
       "name": "0x21a1d74bf75776432ffc94163ddb4bffe35b0b78e7ab8fcb7401ebac0ddb32d9",
@@ -26,6 +26,12 @@
       "keyNumber": 3,
       "timestamp": 1764694512873,
       "attestationHash": "dd2fd9f5926d72ef1d36ea7c6c5ef8b1dfc47ebcaf0b65d6f481f3345404f1c0"
+    },
+    {
+      "name": "0x6120898bd711d52a5f7fb88bae2cef10b334d33e8835e7a34f2cdeb7017e008c",
+      "keyNumber": 4,
+      "timestamp": 1764702547539,
+      "attestationHash": "1dc4268f5c4aae595bfbdc24ecd1e4f76c22d9267ecdff51b9573322c1c11948"
     }
   ],
   "circuitName": "identity_with_merkle",


### PR DESCRIPTION
### **User description**
…8835e7a34f2cdeb7017e008c


___

### **PR Type**
Other


___

### **Description**
- Add new ceremony contribution attestation from participant 0x6120898bd711d52a5f7fb88bae2cef10b334d33e8835e7a34f2cdeb7017e008c

- Update ceremony state to reflect fourth contributor (keyNumber 4)

- Record attestation hash and timestamp for the new contribution


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["New Contributor<br/>0x6120898bd711d52a5f7fb88bae2cef10b334d33e8835e7a34f2cdeb7017e008c"] -->|"Generates ceremony_0004.zkey"| B["Attestation File<br/>0004_0x6120898bd711d52a5f7fb88bae2cef10b334d33e8835e7a34f2cdeb7017e008c.txt"]
  A -->|"Updates state"| C["ceremony_state.json<br/>currentKey: 4"]
  B -->|"Records hash"| C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>0004_0x6120898bd711d52a5f7fb88bae2cef10b334d33e8835e7a34f2cdeb7017e008c.txt</strong><dd><code>Fourth contributor attestation record</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

attestations/0004_0x6120898bd711d52a5f7fb88bae2cef10b334d33e8835e7a34f2cdeb7017e008c.txt

<ul><li>New attestation file documenting the fourth ceremony contribution<br> <li> Records participant identifier, key generation details, and <br>attestation hash<br> <li> Includes timestamp (2025-12-02T19:09:07.537Z) and security warning <br>about key deletion<br> <li> References input key ceremony_0003.zkey and output key <br>ceremony_0004.zkey</ul>


</details>


  </td>
  <td><a href="https://github.com/kynesyslabs/zk_ceremony/pull/8/files#diff-2f84655f239b60ebd78e5019a349c86d0d4809337aea45f96961f00c66946e2d">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ceremony_state.json</strong><dd><code>Update ceremony state with fourth contributor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ceremony_state.json

<ul><li>Increment currentKey from 3 to 4 to reflect new contribution phase<br> <li> Add new contributor entry with keyNumber 4 and participant address<br> <li> Record timestamp (1764702547539) and attestation hash matching the <br>attestation file<br> <li> Maintain existing contributor records and circuit metadata</ul>


</details>


  </td>
  <td><a href="https://github.com/kynesyslabs/zk_ceremony/pull/8/files#diff-d8d8a9fb0fcd5cdefc22048b9a4eb43326eb68994e1d1adcf3041c857ab65387">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Recorded a new ceremony participant contribution with cryptographic attestation verification.
  * Advanced the ceremony state to the next key generation phase.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->