### PR TITLE
Contribution from 0x44db61a6...cae5

### DIFF
--- a/attestations/0007_0x44db61a6775e7438d3e6790845938cb01c03a573c120f3a6e5fd53cfa6efcae5.txt
+++ b/attestations/0007_0x44db61a6775e7438d3e6790845938cb01c03a573c120f3a6e5fd53cfa6efcae5.txt
@@ -1,0 +1,10 @@
+Ceremony Contribution
+Participant: 0x44db61a6775e7438d3e6790845938cb01c03a573c120f3a6e5fd53cfa6efcae5
+Key: ceremony_0007.zkey
+Input Key: ceremony_0006.zkey
+Circuit: identity_with_merkle
+Attestation Hash: 9d758ab9f9d88084f327c835b207003f1b3ab90c6a2fa274de1990b997ad1700
+Timestamp: 2025-12-04T18:56:04.846Z
+
+IMPORTANT: Delete your local copy of this key after passing it to the next contributor!
+This is the "toxic waste" that must be destroyed for security.

--- a/ceremony_state.json
+++ b/ceremony_state.json
@@ -1,7 +1,7 @@
 {
   "initiator": "0x21a1d74bf75776432ffc94163ddb4bffe35b0b78e7ab8fcb7401ebac0ddb32d9",
   "phase": "contributing",
-  "currentKey": 6,
+  "currentKey": 7,
   "contributors": [
     {
       "name": "0x21a1d74bf75776432ffc94163ddb4bffe35b0b78e7ab8fcb7401ebac0ddb32d9",
@@ -44,6 +44,12 @@
       "keyNumber": 6,
       "timestamp": 1764849260433,
       "attestationHash": "1b302775d089a7f648fcd5a1c9b25c07e2a43e9313ba4828586526f2e00e7353"
+    },
+    {
+      "name": "0x44db61a6775e7438d3e6790845938cb01c03a573c120f3a6e5fd53cfa6efcae5",
+      "keyNumber": 7,
+      "timestamp": 1764874564848,
+      "attestationHash": "9d758ab9f9d88084f327c835b207003f1b3ab90c6a2fa274de1990b997ad1700"
     }
   ],
   "circuitName": "identity_with_merkle",


### PR DESCRIPTION
### **User description**
## Contribution from `0x44db61a6775e7438d3e6790845938cb01c03a573c120f3a6e5fd53cfa6efcae5`

### Attestation
```
Ceremony Contribution
Participant: 0x44db61a6775e7438d3e6790845938cb01c03a573c120f3a6e5fd53cfa6efcae5
Key: ceremony_0007.zkey
Input Key: ceremony_0006.zkey
Circuit: identity_with_merkle
Attestation Hash: 9d758ab9f9d88084f327c835b207003f1b3ab90c6a2fa274de1990b997ad1700
Timestamp: 2025-12-04T18:56:04.846Z

IMPORTANT: Delete your local copy of this key after passing it to the next contributor!
This is the "toxic waste" that must be destroyed for security.
```

### Verification
- Contributor address: `0x44db61a6775e7438d3e6790845938cb01c03a573c120f3a6e5fd53cfa6efcae5`
- Branch: `contrib-0x44db61a6775e74`
- Attestation hash: `9d758ab9f9d88084f327c835b207003f1b3ab90c6a2fa274de1990b997ad1700`

---
*Automated contribution via ceremony_contribute.sh*


___

### **PR Type**
Other


___

### **Description**
- Records ceremony contribution from participant 0x44db61a6

- Updates current key number from 6 to 7 in ceremony state

- Adds new contributor entry with attestation hash and timestamp

- Creates attestation file documenting the contribution details


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Contributor 0x44db61a6"] -- "submits contribution" --> B["ceremony_state.json"]
  A -- "creates attestation" --> C["attestations/0007_*.txt"]
  B -- "increments currentKey to 7" --> D["Updated State"]
  C -- "documents contribution" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>0007_0x44db61a6775e7438d3e6790845938cb01c03a573c120f3a6e5fd53cfa6efcae5.txt</strong><dd><code>Add attestation file for contribution 0007</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

attestations/0007_0x44db61a6775e7438d3e6790845938cb01c03a573c120f3a6e5fd53cfa6efcae5.txt

<ul><li>Creates new attestation file for ceremony contribution 0007<br> <li> Records participant address, key references, and circuit name<br> <li> Documents attestation hash and timestamp of contribution<br> <li> Includes security warning about deleting local key copy</ul>


</details>


  </td>
  <td><a href="https://github.com/kynesyslabs/zk_ceremony/pull/11/files#diff-98e0c6857a87087f6d766028cbcc44310a1dae41c1718cd00efd47421d161064">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ceremony_state.json</strong><dd><code>Update ceremony state with new contributor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ceremony_state.json

<ul><li>Increments currentKey from 6 to 7 reflecting new contribution<br> <li> Adds new contributor entry with participant address 0x44db61a6<br> <li> Records keyNumber 7, timestamp 1764874564848, and attestation hash<br> <li> Maintains ceremony state tracking for identity_with_merkle circuit</ul>


</details>


  </td>
  <td><a href="https://github.com/kynesyslabs/zk_ceremony/pull/11/files#diff-d8d8a9fb0fcd5cdefc22048b9a4eb43326eb68994e1d1adcf3041c857ab65387">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Advanced ceremony phase from key 6 to key 7, marking progression in the contribution sequence.
  * Recorded new contributor attestation with metadata and security recommendations for key management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->