### PR TITLE
Contribution from 0xc96b0138...9392

### DIFF
--- a/attestations/0010_0xc96b013809002213f871d6cbd884fb6fe5c4b9eaf9ad0db3d3cccd93c4299392.txt
+++ b/attestations/0010_0xc96b013809002213f871d6cbd884fb6fe5c4b9eaf9ad0db3d3cccd93c4299392.txt
@@ -1,0 +1,10 @@
+Ceremony Contribution
+Participant: 0xc96b013809002213f871d6cbd884fb6fe5c4b9eaf9ad0db3d3cccd93c4299392
+Key: ceremony_0010.zkey
+Input Key: ceremony_0009.zkey
+Circuit: identity_with_merkle
+Attestation Hash: ed8996c7288be274790769743e66622a75d0b4da7604862e18baedbf2172b181
+Timestamp: 2025-12-05T14:07:04.677Z
+
+IMPORTANT: Delete your local copy of this key after passing it to the next contributor!
+This is the "toxic waste" that must be destroyed for security.

--- a/ceremony_state.json
+++ b/ceremony_state.json
@@ -1,7 +1,7 @@
 {
   "initiator": "0x21a1d74bf75776432ffc94163ddb4bffe35b0b78e7ab8fcb7401ebac0ddb32d9",
   "phase": "contributing",
-  "currentKey": 9,
+  "currentKey": 10,
   "contributors": [
     {
       "name": "0x21a1d74bf75776432ffc94163ddb4bffe35b0b78e7ab8fcb7401ebac0ddb32d9",
@@ -62,6 +62,12 @@
       "keyNumber": 9,
       "timestamp": 1764928899123,
       "attestationHash": "ea5ddae84fd9c10defa924b42b7ff85c8c263984fc06950c6e8934cef53f8334"
+    },
+    {
+      "name": "0xc96b013809002213f871d6cbd884fb6fe5c4b9eaf9ad0db3d3cccd93c4299392",
+      "keyNumber": 10,
+      "timestamp": 1764943624679,
+      "attestationHash": "ed8996c7288be274790769743e66622a75d0b4da7604862e18baedbf2172b181"
     }
   ],
   "circuitName": "identity_with_merkle",


### PR DESCRIPTION
### **User description**
## Contribution from `0xc96b013809002213f871d6cbd884fb6fe5c4b9eaf9ad0db3d3cccd93c4299392`

### Attestation
```
Ceremony Contribution
Participant: 0xc96b013809002213f871d6cbd884fb6fe5c4b9eaf9ad0db3d3cccd93c4299392
Key: ceremony_0010.zkey
Input Key: ceremony_0009.zkey
Circuit: identity_with_merkle
Attestation Hash: ed8996c7288be274790769743e66622a75d0b4da7604862e18baedbf2172b181
Timestamp: 2025-12-05T14:07:04.677Z

IMPORTANT: Delete your local copy of this key after passing it to the next contributor!
This is the "toxic waste" that must be destroyed for security.
```

### Verification
- Contributor address: `0xc96b013809002213f871d6cbd884fb6fe5c4b9eaf9ad0db3d3cccd93c4299392`
- Branch: `contrib-0xc96b0138090022`
- Attestation hash: `ed8996c7288be274790769743e66622a75d0b4da7604862e18baedbf2172b181`

---
*Automated contribution via ceremony_contribute.sh*


___

### **PR Type**
Other


___

### **Description**
- Records ceremony contribution from participant 0xc96b0138...9392

- Adds attestation file with contribution verification details

- Updates ceremony state to track key number 10 progression

- Logs contributor information with timestamp and attestation hash


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Contributor 0xc96b0138...9392"] -- "Submits contribution" --> B["Attestation File Created"]
  B -- "Records verification" --> C["ceremony_state.json Updated"]
  C -- "Increments key" --> D["currentKey: 10"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>0010_0xc96b013809002213f871d6cbd884fb6fe5c4b9eaf9ad0db3d3cccd93c4299392.txt</strong><dd><code>Add attestation file for round 10 contribution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

attestations/0010_0xc96b013809002213f871d6cbd884fb6fe5c4b9eaf9ad0db3d3cccd93c4299392.txt

<ul><li>Creates new attestation file for ceremony contribution round 10<br> <li> Records participant address, key references, and circuit information<br> <li> Includes attestation hash for verification and security warning<br> <li> Documents timestamp of contribution submission</ul>


</details>


  </td>
  <td><a href="https://github.com/kynesyslabs/zk_ceremony/pull/14/files#diff-34060530cae6a1c3eb52d1477719841cdbc55481211f509c63dd839fffafa997">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ceremony_state.json</strong><dd><code>Update ceremony state with contributor 10 entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ceremony_state.json

<ul><li>Increments <code>currentKey</code> from 9 to 10 to reflect new contribution<br> <li> Adds new contributor entry with participant address and key number<br> <li> Records timestamp (1764943624679) and attestation hash for <br>verification<br> <li> Maintains ceremony phase as "contributing"</ul>


</details>


  </td>
  <td><a href="https://github.com/kynesyslabs/zk_ceremony/pull/14/files#diff-d8d8a9fb0fcd5cdefc22048b9a4eb43326eb68994e1d1adcf3041c857ab65387">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Documented a new ceremony contribution record with participant information, attestation details, and security guidance for key management.

* **Chores**
  * Updated ceremony state to reflect the latest contribution entry.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->