### PR TITLE
Contribution from 0xd9409b0d...f4ab

### DIFF
--- a/attestations/0011_0xd9409b0d6106e5358b29a56bd4957a1f31fa1a192f00b85cb02709170447f4ab.txt
+++ b/attestations/0011_0xd9409b0d6106e5358b29a56bd4957a1f31fa1a192f00b85cb02709170447f4ab.txt
@@ -1,0 +1,10 @@
+Ceremony Contribution
+Participant: 0xd9409b0d6106e5358b29a56bd4957a1f31fa1a192f00b85cb02709170447f4ab
+Key: ceremony_0011.zkey
+Input Key: ceremony_0010.zkey
+Circuit: identity_with_merkle
+Attestation Hash: 1936000ff6cc9c04bb2e9405c9f218bcafe9b8969ce264053b66fd995a09ceba
+Timestamp: 2025-12-05T17:18:23.799Z
+
+IMPORTANT: Delete your local copy of this key after passing it to the next contributor!
+This is the "toxic waste" that must be destroyed for security.

--- a/ceremony_state.json
+++ b/ceremony_state.json
@@ -1,7 +1,7 @@
 {
   "initiator": "0x21a1d74bf75776432ffc94163ddb4bffe35b0b78e7ab8fcb7401ebac0ddb32d9",
   "phase": "contributing",
-  "currentKey": 10,
+  "currentKey": 11,
   "contributors": [
     {
       "name": "0x21a1d74bf75776432ffc94163ddb4bffe35b0b78e7ab8fcb7401ebac0ddb32d9",
@@ -68,6 +68,12 @@
       "keyNumber": 10,
       "timestamp": 1764943624679,
       "attestationHash": "ed8996c7288be274790769743e66622a75d0b4da7604862e18baedbf2172b181"
+    },
+    {
+      "name": "0xd9409b0d6106e5358b29a56bd4957a1f31fa1a192f00b85cb02709170447f4ab",
+      "keyNumber": 11,
+      "timestamp": 1764955103799,
+      "attestationHash": "1936000ff6cc9c04bb2e9405c9f218bcafe9b8969ce264053b66fd995a09ceba"
     }
   ],
   "circuitName": "identity_with_merkle",


### PR DESCRIPTION
### **User description**
## Contribution from `0xd9409b0d6106e5358b29a56bd4957a1f31fa1a192f00b85cb02709170447f4ab`

### Attestation
```
Ceremony Contribution
Participant: 0xd9409b0d6106e5358b29a56bd4957a1f31fa1a192f00b85cb02709170447f4ab
Key: ceremony_0011.zkey
Input Key: ceremony_0010.zkey
Circuit: identity_with_merkle
Attestation Hash: 1936000ff6cc9c04bb2e9405c9f218bcafe9b8969ce264053b66fd995a09ceba
Timestamp: 2025-12-05T17:18:23.799Z

IMPORTANT: Delete your local copy of this key after passing it to the next contributor!
This is the "toxic waste" that must be destroyed for security.
```

### Verification
- Contributor address: `0xd9409b0d6106e5358b29a56bd4957a1f31fa1a192f00b85cb02709170447f4ab`
- Branch: `contrib-0xd9409b0d6106e5`
- Attestation hash: `1936000ff6cc9c04bb2e9405c9f218bcafe9b8969ce264053b66fd995a09ceba`

---
*Automated contribution via ceremony_contribute.sh*


___

### **PR Type**
Other


___

### **Description**
- Records ceremony contribution from participant 0xd9409b0d6106e5

- Adds attestation file with contribution verification details

- Updates ceremony state to reflect key number 11 completion

- Increments current key counter in state tracking


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Participant Contribution"] --> B["Attestation File Created"]
  A --> C["Ceremony State Updated"]
  B --> D["Key 11 Recorded"]
  C --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>0011_0xd9409b0d6106e5358b29a56bd4957a1f31fa1a192f00b85cb02709170447f4ab.txt</strong><dd><code>Add attestation file for contribution 0011</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

attestations/0011_0xd9409b0d6106e5358b29a56bd4957a1f31fa1a192f00b85cb02709170447f4ab.txt

<ul><li>Creates new attestation file for ceremony contribution 0011<br> <li> Records participant address, key references, and circuit information<br> <li> Includes attestation hash and timestamp for verification<br> <li> Contains security reminder about deleting local key copy</ul>


</details>


  </td>
  <td><a href="https://github.com/kynesyslabs/zk_ceremony/pull/17/files#diff-2a3a4f45daae700493b40ff6d4493ff98098d300a85d5bdf293696f600e128c3">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ceremony_state.json</strong><dd><code>Update ceremony state with contribution 0011</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ceremony_state.json

<ul><li>Increments <code>currentKey</code> from 10 to 11<br> <li> Adds new contributor entry with participant 0xd9409b0d6106e5<br> <li> Records key number 11, timestamp, and attestation hash<br> <li> Maintains ceremony phase as "contributing"</ul>


</details>


  </td>
  <td><a href="https://github.com/kynesyslabs/zk_ceremony/pull/17/files#diff-d8d8a9fb0fcd5cdefc22048b9a4eb43326eb68994e1d1adcf3041c857ab65387">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new contributor attestation and updated the ceremony record to reflect the latest participant's completion of their assigned contribution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->