### PR TITLE
Contribution from 0x4b2817e5...99f4

### DIFF
--- a/attestations/0013_0x4b2817e5a0e71d0a9c2b53f71987df5b7b937d5840370ccf0de21c5ee35199f4.txt
+++ b/attestations/0013_0x4b2817e5a0e71d0a9c2b53f71987df5b7b937d5840370ccf0de21c5ee35199f4.txt
@@ -1,0 +1,10 @@
+Ceremony Contribution
+Participant: 0x4b2817e5a0e71d0a9c2b53f71987df5b7b937d5840370ccf0de21c5ee35199f4
+Key: ceremony_0013.zkey
+Input Key: ceremony_0012.zkey
+Circuit: identity_with_merkle
+Attestation Hash: 514723d7891758632e381bfba8d59efdb17a4669d194d3040d1f56b80a01d471
+Timestamp: 2025-12-06T16:51:55.369Z
+
+IMPORTANT: Delete your local copy of this key after passing it to the next contributor!
+This is the "toxic waste" that must be destroyed for security.

--- a/ceremony_state.json
+++ b/ceremony_state.json
@@ -1,7 +1,7 @@
 {
   "initiator": "0x21a1d74bf75776432ffc94163ddb4bffe35b0b78e7ab8fcb7401ebac0ddb32d9",
   "phase": "contributing",
-  "currentKey": 12,
+  "currentKey": 13,
   "contributors": [
     {
       "name": "0x21a1d74bf75776432ffc94163ddb4bffe35b0b78e7ab8fcb7401ebac0ddb32d9",
@@ -80,6 +80,12 @@
       "keyNumber": 12,
       "timestamp": 1765038211411,
       "attestationHash": "96598509be1f5085a8810e5d3929a0e850078098803f1a6f45e0541607f92385"
+    },
+    {
+      "name": "0x4b2817e5a0e71d0a9c2b53f71987df5b7b937d5840370ccf0de21c5ee35199f4",
+      "keyNumber": 13,
+      "timestamp": 1765039915371,
+      "attestationHash": "514723d7891758632e381bfba8d59efdb17a4669d194d3040d1f56b80a01d471"
     }
   ],
   "circuitName": "identity_with_merkle",


### PR DESCRIPTION
### **User description**
## Contribution from `0x4b2817e5a0e71d0a9c2b53f71987df5b7b937d5840370ccf0de21c5ee35199f4`

### Attestation
```
Ceremony Contribution
Participant: 0x4b2817e5a0e71d0a9c2b53f71987df5b7b937d5840370ccf0de21c5ee35199f4
Key: ceremony_0013.zkey
Input Key: ceremony_0012.zkey
Circuit: identity_with_merkle
Attestation Hash: 514723d7891758632e381bfba8d59efdb17a4669d194d3040d1f56b80a01d471
Timestamp: 2025-12-06T16:51:55.369Z

IMPORTANT: Delete your local copy of this key after passing it to the next contributor!
This is the "toxic waste" that must be destroyed for security.
```

### Verification
- Contributor address: `0x4b2817e5a0e71d0a9c2b53f71987df5b7b937d5840370ccf0de21c5ee35199f4`
- Branch: `contrib-0x4b2817e5a0e71d`
- Attestation hash: `514723d7891758632e381bfba8d59efdb17a4669d194d3040d1f56b80a01d471`

---
*Automated contribution via ceremony_contribute.sh*


___

### **PR Type**
Other


___

### **Description**
- Adds attestation file for ceremony contribution 0013

- Updates ceremony state with new contributor and key number

- Records participant address and attestation hash verification


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Contributor 0x4b2817e5a0e71d"] -->|"Generates Key 0013"| B["Attestation File"]
  A -->|"Records Contribution"| C["ceremony_state.json"]
  B -->|"Contains Hash & Metadata"| D["Verification Data"]
  C -->|"Updates currentKey to 13"| D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>0013_0x4b2817e5a0e71d0a9c2b53f71987df5b7b937d5840370ccf0de21c5ee35199f4.txt</strong><dd><code>Add ceremony contribution attestation file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

attestations/0013_0x4b2817e5a0e71d0a9c2b53f71987df5b7b937d5840370ccf0de21c5ee35199f4.txt

<ul><li>Creates new attestation file documenting ceremony contribution<br> <li> Records participant address, key number, circuit name, and attestation <br>hash<br> <li> Includes timestamp and security warning about toxic waste deletion</ul>


</details>


  </td>
  <td><a href="https://github.com/kynesyslabs/zk_ceremony/pull/19/files#diff-893dc6b500efb83512dadaa2216ed27975c82444af0ac5a0cabbb6ed41d2be2a">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ceremony_state.json</strong><dd><code>Update ceremony state with new contributor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ceremony_state.json

<ul><li>Increments <code>currentKey</code> from 12 to 13<br> <li> Adds new contributor entry with address 0x4b2817e5a0e71d<br> <li> Records keyNumber 13, timestamp, and attestation hash for new <br>contributor</ul>


</details>


  </td>
  <td><a href="https://github.com/kynesyslabs/zk_ceremony/pull/19/files#diff-d8d8a9fb0fcd5cdefc22048b9a4eb43326eb68994e1d1adcf3041c857ab65387">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Recorded formal attestation for ceremony contribution #13, documenting participant verification details, cryptographic key references, circuit specifications, attestation validation hash, and precise contribution timestamp for the record.
  * Updated ceremony state tracker to reflect successful completion of contribution #13, adding contributor identification and attestation hash to maintain comprehensive audit trail and ceremony progress tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->