### PR TITLE
Contribution from 0xecd04750...8619

### DIFF
--- a/attestations/0016_0xecd0475053b697ee26dc4b8d7136f8fe543754b10ee6d3a5580843b29f3d8619.txt
+++ b/attestations/0016_0xecd0475053b697ee26dc4b8d7136f8fe543754b10ee6d3a5580843b29f3d8619.txt
@@ -1,0 +1,10 @@
+Ceremony Contribution
+Participant: 0xecd0475053b697ee26dc4b8d7136f8fe543754b10ee6d3a5580843b29f3d8619
+Key: ceremony_0016.zkey
+Input Key: ceremony_0015.zkey
+Circuit: identity_with_merkle
+Attestation Hash: 8fbd4dd4871c82f110114b8041456be6d2ed4715a68f76aac148594f134200c2
+Timestamp: 2025-12-06T17:28:32.468Z
+
+IMPORTANT: Delete your local copy of this key after passing it to the next contributor!
+This is the "toxic waste" that must be destroyed for security.

--- a/ceremony_state.json
+++ b/ceremony_state.json
@@ -1,7 +1,7 @@
 {
   "initiator": "0x21a1d74bf75776432ffc94163ddb4bffe35b0b78e7ab8fcb7401ebac0ddb32d9",
   "phase": "contributing",
-  "currentKey": 15,
+  "currentKey": 16,
   "contributors": [
     {
       "name": "0x21a1d74bf75776432ffc94163ddb4bffe35b0b78e7ab8fcb7401ebac0ddb32d9",
@@ -98,6 +98,12 @@
       "keyNumber": 15,
       "timestamp": 1765041146491,
       "attestationHash": "f2373ac05eefa45e7e2025656efae609fe509d4f220e72b404fd9b580dde692f"
+    },
+    {
+      "name": "0xecd0475053b697ee26dc4b8d7136f8fe543754b10ee6d3a5580843b29f3d8619",
+      "keyNumber": 16,
+      "timestamp": 1765042112469,
+      "attestationHash": "8fbd4dd4871c82f110114b8041456be6d2ed4715a68f76aac148594f134200c2"
     }
   ],
   "circuitName": "identity_with_merkle",


### PR DESCRIPTION
### **User description**
## Contribution from `0xecd0475053b697ee26dc4b8d7136f8fe543754b10ee6d3a5580843b29f3d8619`

### Attestation
```
Ceremony Contribution
Participant: 0xecd0475053b697ee26dc4b8d7136f8fe543754b10ee6d3a5580843b29f3d8619
Key: ceremony_0016.zkey
Input Key: ceremony_0015.zkey
Circuit: identity_with_merkle
Attestation Hash: 8fbd4dd4871c82f110114b8041456be6d2ed4715a68f76aac148594f134200c2
Timestamp: 2025-12-06T17:28:32.468Z

IMPORTANT: Delete your local copy of this key after passing it to the next contributor!
This is the "toxic waste" that must be destroyed for security.
```

### Verification
- Contributor address: `0xecd0475053b697ee26dc4b8d7136f8fe543754b10ee6d3a5580843b29f3d8619`
- Branch: `contrib-0xecd0475053b697`
- Attestation hash: `8fbd4dd4871c82f110114b8041456be6d2ed4715a68f76aac148594f134200c2`

---
*Automated contribution via ceremony_contribute.sh*


___

### **PR Type**
Other


___

### **Description**
- Records ceremony contribution from participant 0xecd0475053b697

- Adds attestation file with contribution metadata and hash

- Updates ceremony state to reflect key 16 completion

- Registers contributor in ceremony contributors list


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Participant Contribution"] --> B["Attestation File Created"]
  A --> C["Ceremony State Updated"]
  B --> D["Key 16 Registered"]
  C --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>0016_0xecd0475053b697ee26dc4b8d7136f8fe543754b10ee6d3a5580843b29f3d8619.txt</strong><dd><code>Add attestation file for key 16 contribution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

attestations/0016_0xecd0475053b697ee26dc4b8d7136f8fe543754b10ee6d3a5580843b29f3d8619.txt

<ul><li>Creates new attestation file for ceremony contribution<br> <li> Records participant address and key information<br> <li> Documents attestation hash and timestamp<br> <li> Includes security warning about toxic waste deletion</ul>


</details>


  </td>
  <td><a href="https://github.com/kynesyslabs/zk_ceremony/pull/22/files#diff-acd2b5c54e4a15cb4e73e2fd8c647d27f8ea5b391fae9a295bcf2b4b9cae117a">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ceremony_state.json</strong><dd><code>Update ceremony state with contributor 16</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ceremony_state.json

<ul><li>Increments <code>currentKey</code> from 15 to 16<br> <li> Adds new contributor entry for 0xecd0475053b697<br> <li> Records key number 16 with timestamp and attestation hash<br> <li> Maintains ceremony phase as "contributing"</ul>


</details>


  </td>
  <td><a href="https://github.com/kynesyslabs/zk_ceremony/pull/22/files#diff-d8d8a9fb0fcd5cdefc22048b9a4eb43326eb68994e1d1adcf3041c857ab65387">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new attestation record documenting a ceremony contribution with participant details, keys, and timestamps.

* **Chores**
  * Updated ceremony state to reflect current contributor progress and new participant entry.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->