### PR TITLE
Contribution from 0xa73c7c1a...2dab

### DIFF
--- a/attestations/0017_0xa73c7c1a0c784958ef6d121d1ae93309765fd33b6e726e265012282c96482dab.txt
+++ b/attestations/0017_0xa73c7c1a0c784958ef6d121d1ae93309765fd33b6e726e265012282c96482dab.txt
@@ -1,0 +1,10 @@
+Ceremony Contribution
+Participant: 0xa73c7c1a0c784958ef6d121d1ae93309765fd33b6e726e265012282c96482dab
+Key: ceremony_0017.zkey
+Input Key: ceremony_0016.zkey
+Circuit: identity_with_merkle
+Attestation Hash: 7c93a1470d978ef2043244ee434082c1edcfac0bd61e214b69baf64a96b916e0
+Timestamp: 2025-12-06T18:15:34.392Z
+
+IMPORTANT: Delete your local copy of this key after passing it to the next contributor!
+This is the "toxic waste" that must be destroyed for security.

--- a/ceremony_state.json
+++ b/ceremony_state.json
@@ -1,7 +1,7 @@
 {
   "initiator": "0x21a1d74bf75776432ffc94163ddb4bffe35b0b78e7ab8fcb7401ebac0ddb32d9",
   "phase": "contributing",
-  "currentKey": 16,
+  "currentKey": 17,
   "contributors": [
     {
       "name": "0x21a1d74bf75776432ffc94163ddb4bffe35b0b78e7ab8fcb7401ebac0ddb32d9",
@@ -104,6 +104,12 @@
       "keyNumber": 16,
       "timestamp": 1765042112469,
       "attestationHash": "8fbd4dd4871c82f110114b8041456be6d2ed4715a68f76aac148594f134200c2"
+    },
+    {
+      "name": "0xa73c7c1a0c784958ef6d121d1ae93309765fd33b6e726e265012282c96482dab",
+      "keyNumber": 17,
+      "timestamp": 1765044934393,
+      "attestationHash": "7c93a1470d978ef2043244ee434082c1edcfac0bd61e214b69baf64a96b916e0"
     }
   ],
   "circuitName": "identity_with_merkle",


### PR DESCRIPTION
### **User description**
## Contribution from `0xa73c7c1a0c784958ef6d121d1ae93309765fd33b6e726e265012282c96482dab`

### Attestation
```
Ceremony Contribution
Participant: 0xa73c7c1a0c784958ef6d121d1ae93309765fd33b6e726e265012282c96482dab
Key: ceremony_0017.zkey
Input Key: ceremony_0016.zkey
Circuit: identity_with_merkle
Attestation Hash: 7c93a1470d978ef2043244ee434082c1edcfac0bd61e214b69baf64a96b916e0
Timestamp: 2025-12-06T18:15:34.392Z

IMPORTANT: Delete your local copy of this key after passing it to the next contributor!
This is the "toxic waste" that must be destroyed for security.
```

### Verification
- Contributor address: `0xa73c7c1a0c784958ef6d121d1ae93309765fd33b6e726e265012282c96482dab`
- Branch: `contrib-0xa73c7c1a0c7849`
- Attestation hash: `7c93a1470d978ef2043244ee434082c1edcfac0bd61e214b69baf64a96b916e0`

---
*Automated contribution via ceremony_contribute.sh*


___

### **PR Type**
Other


___

### **Description**
- Adds attestation record for ceremony contribution 0017

- Updates ceremony state with new contributor entry

- Increments current key number from 16 to 17

- Records participant address and attestation hash


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Contributor 0xa73c7c1a"] -- "submits contribution" --> B["Attestation File Created"]
  B -- "updates" --> C["Ceremony State"]
  C -- "increments key" --> D["currentKey: 17"]
  C -- "adds entry" --> E["Contributors List"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>0017_0xa73c7c1a0c784958ef6d121d1ae93309765fd33b6e726e265012282c96482dab.txt</strong><dd><code>New attestation file for contribution 0017</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

attestations/0017_0xa73c7c1a0c784958ef6d121d1ae93309765fd33b6e726e265012282c96482dab.txt

<ul><li>Creates new attestation file for ceremony contribution 0017<br> <li> Records participant address and key information<br> <li> Documents circuit name and attestation hash<br> <li> Includes security warning about toxic waste destruction</ul>


</details>


  </td>
  <td><a href="https://github.com/kynesyslabs/zk_ceremony/pull/23/files#diff-a371f0a1ea1abd24540a15348ef4549b7203d33eba9733efd17b6d2b56dbcf8a">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ceremony_state.json</strong><dd><code>Update ceremony state with new contributor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ceremony_state.json

<ul><li>Increments currentKey from 16 to 17<br> <li> Adds new contributor entry with participant address<br> <li> Records keyNumber 17 and timestamp<br> <li> Stores attestation hash for verification</ul>


</details>


  </td>
  <td><a href="https://github.com/kynesyslabs/zk_ceremony/pull/23/files#diff-d8d8a9fb0fcd5cdefc22048b9a4eb43326eb68994e1d1adcf3041c857ab65387">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Recorded a new ceremony participant contribution with attestation. Updated ceremony progress tracking to reflect the latest phase advancement.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->