### PR TITLE
Contribution from 0xf5abbb44...d208

### DIFF
--- a/attestations/0018_0xf5abbb44e3ef6e0ca3318f196dd79e096e96cddb84671bf53a73b341cd07d208.txt
+++ b/attestations/0018_0xf5abbb44e3ef6e0ca3318f196dd79e096e96cddb84671bf53a73b341cd07d208.txt
@@ -1,0 +1,10 @@
+Ceremony Contribution
+Participant: 0xf5abbb44e3ef6e0ca3318f196dd79e096e96cddb84671bf53a73b341cd07d208
+Key: ceremony_0018.zkey
+Input Key: ceremony_0017.zkey
+Circuit: identity_with_merkle
+Attestation Hash: 780df8b1582e4326d023b9a92d4c48838812d3d31ebac7d8646afa9e1ae2d453
+Timestamp: 2025-12-10T13:42:26.186Z
+
+IMPORTANT: Delete your local copy of this key after passing it to the next contributor!
+This is the "toxic waste" that must be destroyed for security.

--- a/ceremony_state.json
+++ b/ceremony_state.json
@@ -1,7 +1,7 @@
 {
   "initiator": "0x21a1d74bf75776432ffc94163ddb4bffe35b0b78e7ab8fcb7401ebac0ddb32d9",
   "phase": "contributing",
-  "currentKey": 17,
+  "currentKey": 18,
   "contributors": [
     {
       "name": "0x21a1d74bf75776432ffc94163ddb4bffe35b0b78e7ab8fcb7401ebac0ddb32d9",
@@ -110,6 +110,12 @@
       "keyNumber": 17,
       "timestamp": 1765044934393,
       "attestationHash": "7c93a1470d978ef2043244ee434082c1edcfac0bd61e214b69baf64a96b916e0"
+    },
+    {
+      "name": "0xf5abbb44e3ef6e0ca3318f196dd79e096e96cddb84671bf53a73b341cd07d208",
+      "keyNumber": 18,
+      "timestamp": 1765374146187,
+      "attestationHash": "780df8b1582e4326d023b9a92d4c48838812d3d31ebac7d8646afa9e1ae2d453"
     }
   ],
   "circuitName": "identity_with_merkle",


### PR DESCRIPTION
### **User description**
## Contribution from `0xf5abbb44e3ef6e0ca3318f196dd79e096e96cddb84671bf53a73b341cd07d208`

### Attestation
```
Ceremony Contribution
Participant: 0xf5abbb44e3ef6e0ca3318f196dd79e096e96cddb84671bf53a73b341cd07d208
Key: ceremony_0018.zkey
Input Key: ceremony_0017.zkey
Circuit: identity_with_merkle
Attestation Hash: 780df8b1582e4326d023b9a92d4c48838812d3d31ebac7d8646afa9e1ae2d453
Timestamp: 2025-12-10T13:42:26.186Z

IMPORTANT: Delete your local copy of this key after passing it to the next contributor!
This is the "toxic waste" that must be destroyed for security.
```

### Verification
- Contributor address: `0xf5abbb44e3ef6e0ca3318f196dd79e096e96cddb84671bf53a73b341cd07d208`
- Branch: `contrib-0xf5abbb44e3ef6e`
- Attestation hash: `780df8b1582e4326d023b9a92d4c48838812d3d31ebac7d8646afa9e1ae2d453`

---
*Automated contribution via ceremony_contribute.sh*


___

### **PR Type**
Other


___

### **Description**
- Adds attestation record for contributor 0xf5abbb44e3ef6e0ca3318f196dd79e096e96cddb84671bf53a73b341cd07d208

- Updates ceremony state to reflect completion of key 18 contribution

- Increments current key counter from 17 to 18

- Records contributor details with timestamp and attestation hash


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Contributor 0xf5abbb44..."] -- "generates key 18" --> B["ceremony_0018.zkey"]
  B -- "creates attestation" --> C["Attestation Record"]
  C -- "updates state" --> D["ceremony_state.json"]
  D -- "increments counter" --> E["currentKey: 18"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>0018_0xf5abbb44e3ef6e0ca3318f196dd79e096e96cddb84671bf53a73b341cd07d208.txt</strong><dd><code>New attestation file for key 18 contribution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

attestations/0018_0xf5abbb44e3ef6e0ca3318f196dd79e096e96cddb84671bf53a73b341cd07d208.txt

<ul><li>Creates new attestation file documenting the ceremony contribution<br> <li> Records participant address, key number, circuit name, and attestation <br>hash<br> <li> Includes security warning about deleting local key copy<br> <li> Timestamps the contribution at 2025-12-10T13:42:26.186Z</ul>


</details>


  </td>
  <td><a href="https://github.com/kynesyslabs/zk_ceremony/pull/24/files#diff-68ab9035aa9542d9ebd16a9e17adb4cfcb962cf66e9dea584ce4719a77926551">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ceremony_state.json</strong><dd><code>Update ceremony state with key 18 contributor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ceremony_state.json

<ul><li>Increments currentKey from 17 to 18<br> <li> Adds new contributor entry with address <br>0xf5abbb44e3ef6e0ca3318f196dd79e096e96cddb84671bf53a73b341cd07d208<br> <li> Records keyNumber 18, timestamp 1765374146187, and attestation hash<br> <li> Maintains ceremony phase as "contributing"</ul>


</details>


  </td>
  <td><a href="https://github.com/kynesyslabs/zk_ceremony/pull/24/files#diff-d8d8a9fb0fcd5cdefc22048b9a4eb43326eb68994e1d1adcf3041c857ab65387">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * New participant contribution to the ceremony has been recorded with attestation hash.
  * Ceremony has advanced to phase 18 with updated state records.
  * Contributor entry with timestamp and attestation details added to the ceremony records.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->