### PR TITLE
Contribution from 0x0d77122d...ced5

### DIFF
--- a/attestations/0019_0x0d77122d8e4353ab1e493c448e60019d631848e1f6a7bc66d8fbf3984406ced5.txt
+++ b/attestations/0019_0x0d77122d8e4353ab1e493c448e60019d631848e1f6a7bc66d8fbf3984406ced5.txt
@@ -1,0 +1,10 @@
+Ceremony Contribution
+Participant: 0x0d77122d8e4353ab1e493c448e60019d631848e1f6a7bc66d8fbf3984406ced5
+Key: ceremony_0019.zkey
+Input Key: ceremony_0018.zkey
+Circuit: identity_with_merkle
+Attestation Hash: 7cbbbb45c5f05bb766e724a52816ddb63e2498a2875e54bb71642fcd333b8cc8
+Timestamp: 2025-12-11T21:19:22.747Z
+
+IMPORTANT: Delete your local copy of this key after passing it to the next contributor!
+This is the "toxic waste" that must be destroyed for security.

--- a/ceremony_state.json
+++ b/ceremony_state.json
@@ -1,7 +1,7 @@
 {
   "initiator": "0x21a1d74bf75776432ffc94163ddb4bffe35b0b78e7ab8fcb7401ebac0ddb32d9",
   "phase": "contributing",
-  "currentKey": 18,
+  "currentKey": 19,
   "contributors": [
     {
       "name": "0x21a1d74bf75776432ffc94163ddb4bffe35b0b78e7ab8fcb7401ebac0ddb32d9",
@@ -116,6 +116,12 @@
       "keyNumber": 18,
       "timestamp": 1765374146187,
       "attestationHash": "780df8b1582e4326d023b9a92d4c48838812d3d31ebac7d8646afa9e1ae2d453"
+    },
+    {
+      "name": "0x0d77122d8e4353ab1e493c448e60019d631848e1f6a7bc66d8fbf3984406ced5",
+      "keyNumber": 19,
+      "timestamp": 1765487962750,
+      "attestationHash": "7cbbbb45c5f05bb766e724a52816ddb63e2498a2875e54bb71642fcd333b8cc8"
     }
   ],
   "circuitName": "identity_with_merkle",


### PR DESCRIPTION
### **User description**
## Contribution from `0x0d77122d8e4353ab1e493c448e60019d631848e1f6a7bc66d8fbf3984406ced5`

### Attestation
```
Ceremony Contribution
Participant: 0x0d77122d8e4353ab1e493c448e60019d631848e1f6a7bc66d8fbf3984406ced5
Key: ceremony_0019.zkey
Input Key: ceremony_0018.zkey
Circuit: identity_with_merkle
Attestation Hash: 7cbbbb45c5f05bb766e724a52816ddb63e2498a2875e54bb71642fcd333b8cc8
Timestamp: 2025-12-11T21:19:22.747Z

IMPORTANT: Delete your local copy of this key after passing it to the next contributor!
This is the "toxic waste" that must be destroyed for security.
```

### Verification
- Contributor address: `0x0d77122d8e4353ab1e493c448e60019d631848e1f6a7bc66d8fbf3984406ced5`
- Branch: `contrib-0x0d77122d8e4353`
- Attestation hash: `7cbbbb45c5f05bb766e724a52816ddb63e2498a2875e54bb71642fcd333b8cc8`

---
*Automated contribution via ceremony_contribute.sh*


___

### **PR Type**
Other


___

### **Description**
- Records ceremony contribution from participant 0x0d77122d8e4353

- Updates current key number from 18 to 19 in ceremony state

- Adds contributor entry with attestation hash and timestamp

- Creates attestation file documenting the contribution details


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Participant Contribution"] --> B["Attestation File Created"]
  A --> C["Ceremony State Updated"]
  B --> D["Key 0019 Recorded"]
  C --> D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>0019_0x0d77122d8e4353ab1e493c448e60019d631848e1f6a7bc66d8fbf3984406ced5.txt</strong><dd><code>New attestation file for contribution 0019</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

attestations/0019_0x0d77122d8e4353ab1e493c448e60019d631848e1f6a7bc66d8fbf3984406ced5.txt

<ul><li>Creates new attestation file for ceremony contribution 0019<br> <li> Documents participant address, key number, circuit name, and <br>attestation hash<br> <li> Includes timestamp of contribution (2025-12-11T21:19:22.747Z)<br> <li> Contains security reminder about deleting local key copy</ul>


</details>


  </td>
  <td><a href="https://github.com/kynesyslabs/zk_ceremony/pull/25/files#diff-adf7c28347e39854664bea6c7bfc3240a54440d9c8c5eeccf071a27a392c81be">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ceremony_state.json</strong><dd><code>Update ceremony state with contribution 0019</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ceremony_state.json

<ul><li>Increments <code>currentKey</code> from 18 to 19<br> <li> Adds new contributor entry for participant 0x0d77122d8e4353<br> <li> Records keyNumber 19, timestamp 1765487962750, and attestation hash<br> <li> Maintains ceremony phase as "contributing"</ul>


</details>


  </td>
  <td><a href="https://github.com/kynesyslabs/zk_ceremony/pull/25/files#diff-d8d8a9fb0fcd5cdefc22048b9a4eb43326eb68994e1d1adcf3041c857ab65387">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Advanced ceremony to phase 19 with new contributor attestation recorded.
  * Updated ceremony state tracking with contributor participation details.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->