### PR TITLE
Contribution from 0xf5e673df...16b0

### DIFF
--- a/attestations/0020_0xf5e673dfdf93b56e69f44badc946f3584a84816f5157a25be2173ca5c1dd16b0.txt
+++ b/attestations/0020_0xf5e673dfdf93b56e69f44badc946f3584a84816f5157a25be2173ca5c1dd16b0.txt
@@ -1,0 +1,10 @@
+Ceremony Contribution
+Participant: 0xf5e673dfdf93b56e69f44badc946f3584a84816f5157a25be2173ca5c1dd16b0
+Key: ceremony_0020.zkey
+Input Key: ceremony_0019.zkey
+Circuit: identity_with_merkle
+Attestation Hash: 9af9cb1a816c83ab2441f0f42690bee72905c25252e4c37e34b48b076f69bd86
+Timestamp: 2025-12-13T04:49:57.736Z
+
+IMPORTANT: Delete your local copy of this key after passing it to the next contributor!
+This is the "toxic waste" that must be destroyed for security.

--- a/ceremony_state.json
+++ b/ceremony_state.json
@@ -1,7 +1,7 @@
 {
   "initiator": "0x21a1d74bf75776432ffc94163ddb4bffe35b0b78e7ab8fcb7401ebac0ddb32d9",
   "phase": "contributing",
-  "currentKey": 19,
+  "currentKey": 20,
   "contributors": [
     {
       "name": "0x21a1d74bf75776432ffc94163ddb4bffe35b0b78e7ab8fcb7401ebac0ddb32d9",
@@ -122,6 +122,12 @@
       "keyNumber": 19,
       "timestamp": 1765487962750,
       "attestationHash": "7cbbbb45c5f05bb766e724a52816ddb63e2498a2875e54bb71642fcd333b8cc8"
+    },
+    {
+      "name": "0xf5e673dfdf93b56e69f44badc946f3584a84816f5157a25be2173ca5c1dd16b0",
+      "keyNumber": 20,
+      "timestamp": 1765601397737,
+      "attestationHash": "9af9cb1a816c83ab2441f0f42690bee72905c25252e4c37e34b48b076f69bd86"
     }
   ],
   "circuitName": "identity_with_merkle",


### PR DESCRIPTION
### **User description**
## Contribution from `0xf5e673dfdf93b56e69f44badc946f3584a84816f5157a25be2173ca5c1dd16b0`

### Attestation
```
Ceremony Contribution
Participant: 0xf5e673dfdf93b56e69f44badc946f3584a84816f5157a25be2173ca5c1dd16b0
Key: ceremony_0020.zkey
Input Key: ceremony_0019.zkey
Circuit: identity_with_merkle
Attestation Hash: 9af9cb1a816c83ab2441f0f42690bee72905c25252e4c37e34b48b076f69bd86
Timestamp: 2025-12-13T04:49:57.736Z

IMPORTANT: Delete your local copy of this key after passing it to the next contributor!
This is the "toxic waste" that must be destroyed for security.
```

### Verification
- Contributor address: `0xf5e673dfdf93b56e69f44badc946f3584a84816f5157a25be2173ca5c1dd16b0`
- Branch: `contrib-0xf5e673dfdf93b5`
- Attestation hash: `9af9cb1a816c83ab2441f0f42690bee72905c25252e4c37e34b48b076f69bd86`

---
*Automated contribution via ceremony_contribute.sh*


___

### **PR Type**
Other


___

### **Description**
- Records ceremony contribution from participant 0xf5e673dfdf93b56e69f44badc946f3584a84816f5157a25be2173ca5c1dd16b0

- Creates attestation file with contribution metadata and security warnings

- Updates ceremony state to advance key number from 19 to 20

- Adds contributor entry with timestamp and attestation hash


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Contributor 0xf5e673df..."] -- "generates key 0020" --> B["Attestation File"]
  B -- "records metadata" --> C["ceremony_state.json"]
  C -- "updates currentKey to 20" --> D["Ceremony Progress"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>0020_0xf5e673dfdf93b56e69f44badc946f3584a84816f5157a25be2173ca5c1dd16b0.txt</strong><dd><code>New attestation file for key 0020 contribution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

attestations/0020_0xf5e673dfdf93b56e69f44badc946f3584a84816f5157a25be2173ca5c1dd16b0.txt

<ul><li>Creates new attestation file documenting the ceremony contribution<br> <li> Records participant address, key number, circuit name, and attestation <br>hash<br> <li> Includes timestamp of contribution (2025-12-13T04:49:57.736Z)<br> <li> Contains security warning about deleting local key copy</ul>


</details>


  </td>
  <td><a href="https://github.com/kynesyslabs/zk_ceremony/pull/27/files#diff-874695d30b8749a910120032775014de74c7b33aba581de8b525e6f331f2c5fa">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ceremony_state.json</strong><dd><code>Update ceremony state with key 0020 contribution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ceremony_state.json

<ul><li>Increments <code>currentKey</code> from 19 to 20<br> <li> Adds new contributor entry with participant address <br>0xf5e673dfdf93b56e69f44badc946f3584a84816f5157a25be2173ca5c1dd16b0<br> <li> Records keyNumber 20, timestamp 1765601397737, and attestation hash<br> <li> Maintains ceremony phase as "contributing"</ul>


</details>


  </td>
  <td><a href="https://github.com/kynesyslabs/zk_ceremony/pull/27/files#diff-d8d8a9fb0fcd5cdefc22048b9a4eb43326eb68994e1d1adcf3041c857ab65387">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Advanced the ceremony to the next phase with a new contributor attestation recorded.
  * Updated ceremony state to reflect the latest participant contribution and progression.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->